### PR TITLE
CMakeLists.txt: respect $sysroot in generated cmake config

### DIFF
--- a/qt5/dbusaddons/CMakeLists.txt
+++ b/qt5/dbusaddons/CMakeLists.txt
@@ -38,7 +38,8 @@ generate_export_header(Fcitx5Qt5DBusAddons BASE_NAME Fcitx5Qt5DBusAddons)
 add_library(Fcitx5Qt5::DBusAddons ALIAS Fcitx5Qt5DBusAddons)
 
 target_include_directories(Fcitx5Qt5DBusAddons PUBLIC "$<BUILD_INTERFACE:${fcitxqtdbusaddons_INCLUDE_DIRS}>")
-target_include_directories(Fcitx5Qt5DBusAddons INTERFACE "$<INSTALL_INTERFACE:${Fcitx5Qt5_INCLUDE_INSTALL_DIR}/Fcitx5Qt5DBusAddons>")
+target_include_directories(Fcitx5Qt5DBusAddons
+                           INTERFACE $<INSTALL_INTERFACE:include/Fcitx5Qt5/Fcitx5Qt5DBusAddons>)
 
 set_target_properties(Fcitx5Qt5DBusAddons
                       PROPERTIES VERSION 1.0

--- a/qt5/widgetsaddons/CMakeLists.txt
+++ b/qt5/widgetsaddons/CMakeLists.txt
@@ -48,7 +48,8 @@ generate_export_header(Fcitx5Qt5WidgetsAddons BASE_NAME Fcitx5Qt5WidgetsAddons)
 add_library(Fcitx5Qt5::WidgetsAddons ALIAS Fcitx5Qt5WidgetsAddons)
 
 target_include_directories(Fcitx5Qt5WidgetsAddons PUBLIC "$<BUILD_INTERFACE:${fcitxqtwidgetsaddons_INCLUDE_DIRS}>")
-target_include_directories(Fcitx5Qt5WidgetsAddons INTERFACE "$<INSTALL_INTERFACE:${Fcitx5Qt5_INCLUDE_INSTALL_DIR}/Fcitx5QtWidgetsAddons>")
+target_include_directories(Fcitx5Qt5WidgetsAddons
+	INTERFACE $<INSTALL_INTERFACE:include/Fcitx5Qt5/Fcitx5Qt5WidgetsAddons>)
 
 set_target_properties(Fcitx5Qt5WidgetsAddons
                       PROPERTIES VERSION 1.0


### PR DESCRIPTION
This is forward port from f41cd5f, (CMakeLists.txt: respect $sysroot
in generated cmake config, 2020-05-16) of fcitx-qt5.

Current CMakeLists.txt generates Fcitx*Targets.cmake,
with INTERFACE_INCLUDE_DIRECTORIES set to static value, that doesn't
respect CMAKE_FIND_ROOT_PATH when cross compile for other platform.

Use the documented: `$<INSTALL_INTERFACE:include/mylib>` [1] instead.

[1]: https://cmake.org/cmake/help/v3.0/command/target_include_directories.html