### PR TITLE
Candidate window: always flip to text top when out of window

### DIFF
--- a/qt5/platforminputcontext/fcitxcandidatewindow.cpp
+++ b/qt5/platforminputcontext/fcitxcandidatewindow.cpp
@@ -429,12 +429,8 @@ void fcitx::FcitxCandidateWindow::updateClientSideUI(
     }
 
     if (y + actualSize_.height() > screenGeometry.bottom()) {
-        if (y > screenGeometry.bottom()) {
-            y = screenGeometry.bottom() - actualSize_.height() - 40;
-        } else { /* better position the window */
-            y = y - actualSize_.height() -
-                ((cursorRect.height() == 0) ? 40 : cursorRect.height());
-        }
+        y = y - actualSize_.height() -
+            ((cursorRect.height() == 0) ? 40 : cursorRect.height());
     }
 
     if (y < screenGeometry.top()) {


### PR DESCRIPTION
`y > screenGeometry.bottom()` may be caused by window decoration (CSD titlebar). It's still correct to just flip.

This will position the candidate window exactly at the top of text when inputting into Telegram chats, instead of floating high above the text.