### PR TITLE
Fix compilation error for qfcitxplatforminputcontext.cpp

### DIFF
--- a/qt5/platforminputcontext/qfcitxplatforminputcontext.cpp
+++ b/qt5/platforminputcontext/qfcitxplatforminputcontext.cpp
@@ -28,6 +28,7 @@
 #include "qfcitxplatforminputcontext.h"
 #include "qtkey.h"
 
+#include <array>
 #include <memory>
 #include <xcb/xcb.h>
 


### PR DESCRIPTION
The compilation error happens in FreeBSD CURRENT 610d908f8a6.

Error:
	/wrkdir/textproc/fcitx5-qt/work/fcitx5-qt-5.0.7/qt5/platforminputcontext/qfcitxplatforminputcontext.cpp:973:31: error: implicit instantiation of undefined template 'std::array<char, 256>'
	        std::array<char, 256> buffer;
	                              ^
	/usr/include/c++/v1/__tuple:219:64: note: template is declared here
	template <class _Tp, size_t _Size> struct _LIBCPP_TEMPLATE_VIS array;

This fix adds #include <array> to the affected source file.