### PR TITLE
cmake does not need such a high version,

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.13)
 project(fcitx5-qt VERSION 5.0.10)
 set(FCITX5_QT_VERSION ${PROJECT_VERSION})
 


### PR DESCRIPTION
it is very difficult to promote the system upgrade,
and I do not want the difference between the changes
and the upstream to be too large