### PR TITLE
Change the default behavior of virtual keyboard visibility

### DIFF
--- a/qt4/dbusaddons/fcitxqtinputcontextproxy_p.h
+++ b/qt4/dbusaddons/fcitxqtinputcontextproxy_p.h
@@ -112,6 +112,20 @@ public:
             arg2.setValue(display_);
             list << arg2;
         }
+        // Qt has good support for showing virtual keyboard, so we should
+        // disable the default behavior supported by fcitx5
+        FcitxQtStringKeyValue clientControlVirtualkeyboardShow;
+        clientControlVirtualkeyboardShow.setKey(
+            "clientControlVirtualkeyboardShow");
+        clientControlVirtualkeyboardShow.setValue("true");
+        list << clientControlVirtualkeyboardShow;
+        // Qt has poor support for hiding virtual keyboard, so we should enable
+        // the default behavior supported by fcitx5
+        FcitxQtStringKeyValue clientControlVirtualkeyboardHide;
+        clientControlVirtualkeyboardHide.setKey(
+            "clientControlVirtualkeyboardHide");
+        clientControlVirtualkeyboardHide.setValue("false");
+        list << clientControlVirtualkeyboardHide;
 
         auto result = improxy_->CreateInputContext(list);
         createInputContextWatcher_ = new QDBusPendingCallWatcher(result);

--- a/qt5/dbusaddons/fcitxqtinputcontextproxy_p.h
+++ b/qt5/dbusaddons/fcitxqtinputcontextproxy_p.h
@@ -110,6 +110,21 @@ public:
             list << arg2;
         }
 
+        // Qt has good support for showing virtual keyboard, so we should
+        // disable the default behavior supported by fcitx5
+        FcitxQtStringKeyValue clientControlVirtualkeyboardShow;
+        clientControlVirtualkeyboardShow.setKey(
+            "clientControlVirtualkeyboardShow");
+        clientControlVirtualkeyboardShow.setValue("true");
+        list << clientControlVirtualkeyboardShow;
+        // Qt has poor support for hiding virtual keyboard, so we should enable
+        // the default behavior supported by fcitx5
+        FcitxQtStringKeyValue clientControlVirtualkeyboardHide;
+        clientControlVirtualkeyboardHide.setKey(
+            "clientControlVirtualkeyboardHide");
+        clientControlVirtualkeyboardHide.setValue("false");
+        list << clientControlVirtualkeyboardHide;
+
         auto result = improxy_->CreateInputContext(list);
         createInputContextWatcher_ = new QDBusPendingCallWatcher(result);
         QObject::connect(createInputContextWatcher_,

--- a/qt6/dbusaddons/fcitxqtinputcontextproxy_p.h
+++ b/qt6/dbusaddons/fcitxqtinputcontextproxy_p.h
@@ -110,6 +110,21 @@ public:
             list << arg2;
         }
 
+        // Qt has good support for showing virtual keyboard, so we should
+        // disable the default behavior supported by fcitx5
+        FcitxQtStringKeyValue clientControlVirtualkeyboardShow;
+        clientControlVirtualkeyboardShow.setKey(
+            "clientControlVirtualkeyboardShow");
+        clientControlVirtualkeyboardShow.setValue("true");
+        list << clientControlVirtualkeyboardShow;
+        // Qt has poor support for hiding virtual keyboard, so we should enable
+        // the default behavior supported by fcitx5
+        FcitxQtStringKeyValue clientControlVirtualkeyboardHide;
+        clientControlVirtualkeyboardHide.setKey(
+            "clientControlVirtualkeyboardHide");
+        clientControlVirtualkeyboardHide.setValue("false");
+        list << clientControlVirtualkeyboardHide;
+
         auto result = improxy_->CreateInputContext(list);
         createInputContextWatcher_ = new QDBusPendingCallWatcher(result);
         QObject::connect(createInputContextWatcher_,


### PR DESCRIPTION
1. Qt has good support for showing virtual keyboard, so we should disable the default behavior supported by fcitx5

2. Qt has poor support for hiding virtual keyboard, so we should enable the default behavior supported by fcitx5