### PR TITLE
QFileSystemWatcher object should not be deleted immediately in the slot function

### DIFF
--- a/qt5/platforminputcontext/fcitx4watcher.cpp
+++ b/qt5/platforminputcontext/fcitx4watcher.cpp
@@ -241,7 +241,7 @@ void Fcitx4Watcher::watchSocketFile() {
 }
 
 void Fcitx4Watcher::unwatchSocketFile() {
-    delete fsWatcher_;
+    fsWatcher_->deleteLater();
     fsWatcher_ = nullptr;
 }
 


### PR DESCRIPTION
If QFileSystemWatcher object is deleted immediately in the slot function, the program may crash.