### PR TITLE
Fix can't switch input methods through the systray menu

### DIFF
--- a/qt5/platforminputcontext/qfcitxplatforminputcontext.cpp
+++ b/qt5/platforminputcontext/qfcitxplatforminputcontext.cpp
@@ -541,7 +541,7 @@ void QFcitxPlatformInputContext::setFocusObject(QObject *object) {
         return;
     }
 
-    if (proxy) {
+    if (proxy && !shouldDisableInputMethod()) {
         proxy->focusIn();
         // We need to delegate this otherwise it may cause self-recursion in
         // certain application like libreoffice.
@@ -634,7 +634,7 @@ void QFcitxPlatformInputContext::createInputContextFinished(
 #else
         Q_UNUSED(uuid);
 #endif
-        if (window && window == w) {
+        if (window && window == w && !shouldDisableInputMethod()) {
             cursorRectChanged();
             proxy->focusIn();
         }


### PR DESCRIPTION
Call focusIn only when input method is accepted, so that focusIn will not be called when the systray menu pops up.