### PR TITLE
Avoid calling qmake -query from CMakeLists.txt

### DIFF
--- a/qt6/platforminputcontext/CMakeLists.txt
+++ b/qt6/platforminputcontext/CMakeLists.txt
@@ -63,16 +63,4 @@ if (ENABLE_QT6_WAYLAND_WORKAROUND)
         Qt6::WaylandClientPrivate)
 endif()
 
-get_target_property(_QT6_QMAKE_EXECUTABLE Qt6::qmake LOCATION)
-execute_process(
-    COMMAND ${_QT6_QMAKE_EXECUTABLE} -query "QT_INSTALL_PLUGINS"
-    RESULT_VARIABLE return_code
-    OUTPUT_VARIABLE _QT6PLUGINDIR
-)
-if(return_code EQUAL 0)
-    string(STRIP "${_QT6PLUGINDIR}" _QT6PLUGINDIR)
-else()
-    message(FATAL_ERROR "QMake Qt6 call failed: ${return_code}")
-endif()
-set(CMAKE_INSTALL_QT6PLUGINDIR ${_QT6PLUGINDIR} CACHE PATH "Qt6 plugin dir")
-install(TARGETS fcitx5platforminputcontextplugin-qt6 DESTINATION ${CMAKE_INSTALL_QT6PLUGINDIR}/platforminputcontexts)
+install(TARGETS fcitx5platforminputcontextplugin-qt6 DESTINATION ${QT6_INSTALL_PLUGINS}/platforminputcontexts)


### PR DESCRIPTION
There is no need to call qmake here. All install paths are accessible directly from CMake: <https://code.qt.io/cgit/qt/qtbase.git/tree/cmake/QtInstallPaths.cmake.in>.