### PR TITLE
refactor: replace non-empty QString constructors with QStringLiteral()

### DIFF
--- a/qt5/platforminputcontext/fcitx4inputcontextproxy_p.h
+++ b/qt5/platforminputcontext/fcitx4inputcontextproxy_p.h
@@ -116,7 +116,7 @@ public:
                           unsigned int>
             reply(*createInputContextWatcher_);
 
-        QString path = QString("/inputcontext_%1").arg(reply.value());
+        QString path = QStringLiteral("/inputcontext_%1").arg(reply.value());
         icproxy_ = new Fcitx4InputContextProxyImpl(improxy_->service(), path,
                                                    improxy_->connection(), q);
         QObject::connect(icproxy_, &Fcitx4InputContextProxyImpl::CommitString,

--- a/qt5/platforminputcontext/fcitx4watcher.cpp
+++ b/qt5/platforminputcontext/fcitx4watcher.cpp
@@ -48,7 +48,7 @@ int displayNumber() {
 
 QString socketFile() {
     QString filename =
-        QString("%1-%2")
+        QStringLiteral("%1-%2")
             .arg(QString::fromLatin1(QDBusConnection::localMachineId()))
             .arg(displayNumber());
 
@@ -56,7 +56,7 @@ QString socketFile() {
     if (home.isEmpty()) {
         home = QDir::homePath().append(QLatin1String("/.config"));
     }
-    return QString("%1/fcitx/dbus/%2").arg(home).arg(filename);
+    return QStringLiteral("%1/fcitx/dbus/%2").arg(home).arg(filename);
 }
 
 namespace fcitx {
@@ -64,13 +64,13 @@ namespace fcitx {
 QString newUniqueConnectionName() {
     static int idx = 0;
     const auto newIdx = idx++;
-    return QString("_fcitx4_%1").arg(newIdx);
+    return QStringLiteral("_fcitx4_%1").arg(newIdx);
 }
 
 Fcitx4Watcher::Fcitx4Watcher(QDBusConnection sessionBus, QObject *parent)
     : QObject(parent), connection_(nullptr), sessionBus_(sessionBus),
       socketFile_(socketFile()),
-      serviceName_(QString("org.fcitx.Fcitx-%1").arg(displayNumber())),
+      serviceName_(QStringLiteral("org.fcitx.Fcitx-%1").arg(displayNumber())),
       availability_(false), uniqueConnectionName_(newUniqueConnectionName()) {}
 
 Fcitx4Watcher::~Fcitx4Watcher() {

--- a/qt5/platforminputcontext/fcitxtheme.cpp
+++ b/qt5/platforminputcontext/fcitxtheme.cpp
@@ -39,7 +39,7 @@ QColor readColor(const QSettings &settings, const QString &name,
         } else if (colorString.size() == 9) {
             // Qt accept "#AARRGGBB"
             auto newColorString =
-                QString("#%1%2")
+                QStringLiteral("#%1%2")
                     .arg(colorString.mid(7, 2), colorString.mid(1, 6))
                     .toUpper();
             color = QColor(newColorString);
@@ -55,13 +55,13 @@ void BackgroundImage::load(const QString &name, QSettings &settings) {
     if (auto image = settings.value("Image").toString(); !image.isEmpty()) {
         auto file = QStandardPaths::locate(
             QStandardPaths::GenericDataLocation,
-            QString("fcitx5/themes/%1/%2").arg(name, image));
+            QStringLiteral("fcitx5/themes/%1/%2").arg(name, image));
         image_.load(file);
     }
     if (auto image = settings.value("Overlay").toString(); !image.isEmpty()) {
         auto file = QStandardPaths::locate(
             QStandardPaths::GenericDataLocation,
-            QString("fcitx5/themes/%1/%2").arg(name, image));
+            QStringLiteral("fcitx5/themes/%1/%2").arg(name, image));
         overlay_.load(file);
     }
 
@@ -130,7 +130,7 @@ void ActionImage::load(const QString &name, QSettings &settings) {
     if (auto image = settings.value("Image").toString(); !image.isEmpty()) {
         auto file = QStandardPaths::locate(
             QStandardPaths::GenericDataLocation,
-            QString("fcitx5/themes/%1/%2").arg(name, image));
+            QStringLiteral("fcitx5/themes/%1/%2").arg(name, image));
         image_.load(file);
         valid_ = !image_.isNull();
     }
@@ -185,7 +185,8 @@ void FcitxTheme::themeChanged() {
     if (!themeConfigPath_.isEmpty()) {
         watcher_->removePath(themeConfigPath_);
     }
-    auto themeConfig = QString("/fcitx5/themes/%1/theme.conf").arg(theme_);
+    auto themeConfig =
+        QStringLiteral("/fcitx5/themes/%1/theme.conf").arg(theme_);
     themeConfigPath_ =
         QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation)
             .append(themeConfig);


### PR DESCRIPTION
- Qt provides a macro `QStringLiteral()`, which makes constructing QString objects from string literals more efficient.