### PR TITLE
Handle QLineEdit focus object correctly with QCompleter in Qt6

### DIFF
--- a/qt5/platforminputcontext/qfcitxplatforminputcontext.cpp
+++ b/qt5/platforminputcontext/qfcitxplatforminputcontext.cpp
@@ -1249,9 +1249,6 @@ QWindow *QFcitxPlatformInputContext::focusWindowWrapper() const {
             break;
         }
         QObject *realFocusObject = focusObjectWrapper();
-        if (qGuiApp->focusObject() == realFocusObject) {
-            break;
-        }
         auto *widget = qobject_cast<QWidget *>(realFocusObject);
         if (!widget) {
             break;


### PR DESCRIPTION
In Qt6, when using QLineEdit with QCompleter during Chinese input:
- qGuiApp->focusObject() and realFocusObject are both QLineEdit
- This is logically correct as the focus is indeed on QLineEdit
- However, it caused filterEvent to return false and trigger unwanted keypress events
- Remove redundant check to ensure proper input method handling

This fixes input method behavior when using QLineEdit with QCompleter in Qt6, especially for Chinese input scenarios.