### PR TITLE
Window crash (Fedora 42 with kde 6.4.1)

### DIFF
--- a/qt5/platforminputcontext/fcitxcandidatewindow.cpp
+++ b/qt5/platforminputcontext/fcitxcandidatewindow.cpp
@@ -126,8 +126,7 @@ FcitxCandidateWindow::FcitxCandidateWindow(QWindow *window,
 #if defined(FCITX_ENABLE_QT6_WAYLAND_WORKAROUND) &&                            \
     QT_VERSION >= QT_VERSION_CHECK(6, 6, 0)
         if (auto instance = QtWaylandClient::QWaylandIntegration::instance()) {
-            for (QtWaylandClient::QWaylandDisplay::RegistryGlobal global :
-                 instance->display()->globals()) {
+            for (auto& global : instance->display()->globals()) {
                 if (global.interface == QLatin1String("xdg_wm_base")) {
                     xdgWmBase_.reset(
                         new XdgWmBase(instance->display()->wl_registry(),

--- a/qt5/platforminputcontext/fcitxcandidatewindow.cpp
+++ b/qt5/platforminputcontext/fcitxcandidatewindow.cpp
@@ -126,7 +126,8 @@ FcitxCandidateWindow::FcitxCandidateWindow(QWindow *window,
 #if defined(FCITX_ENABLE_QT6_WAYLAND_WORKAROUND) &&                            \
     QT_VERSION >= QT_VERSION_CHECK(6, 6, 0)
         if (auto instance = QtWaylandClient::QWaylandIntegration::instance()) {
-            for (auto& global : instance->display()->globals()) {
+            auto& globals = instance->display()->globals();
+            for (const auto& global : globals) {
                 if (global.interface == QLatin1String("xdg_wm_base")) {
                     xdgWmBase_.reset(
                         new XdgWmBase(instance->display()->wl_registry(),


### PR DESCRIPTION
fixes: https://github.com/fcitx/fcitx5/issues/1380

The crash seems to be reference related, so I give it a shot to iterate by reference instead. This seems to work on my machine.

Fedora 42 (KDE edition) with KDE 6.4.1.