### PR TITLE
qt5: fix qt5 gui-wrapper does not work

### DIFF
--- a/qt5/widgetsaddons/fcitxqtconfiguifactory.cpp
+++ b/qt5/widgetsaddons/fcitxqtconfiguifactory.cpp
@@ -72,7 +72,7 @@ bool FcitxQtConfigUIFactory::test(const QString &file) {
 
 void FcitxQtConfigUIFactoryPrivate::scan() {
     auto addonFiles = fcitx::StandardPaths::global().locate(
-        fcitx::StandardPathsType::Addon, "qt6",
+        fcitx::StandardPathsType::Addon, "qt5",
         [](const std::filesystem::path &path) {
             return QLibrary::isLibrary(QString::fromStdString(path));
         },


### PR DESCRIPTION
Fixes: 31caa7704243 ("drop qt5 quickphrase editor and port to StandardPaths")