### PR TITLE
fix(cursor rectangle):In a Wayland environment, coordinate settings are abnormal

### DIFF
--- a/qt5/platforminputcontext/qfcitxplatforminputcontext.cpp
+++ b/qt5/platforminputcontext/qfcitxplatforminputcontext.cpp
@@ -595,6 +595,7 @@ void QFcitxPlatformInputContext::cursorRectChanged() {
     qreal scale = inputWindow->devicePixelRatio();
     if (data.capability & FcitxCapabilityFlag_RelativeRect) {
         auto margins = inputWindow->frameMargins();
+        r.translate(inputWindow->framePosition());
         r.translate(margins.left(), margins.top());
         r = QRect(r.topLeft() * scale, r.size() * scale);
         if (data.rect != r) {


### PR DESCRIPTION
在wayland环境，使用第三方输入法，如搜狗输入法，在qt应用输入文字时，会出现候选词窗口位置异常的问题
发现目前逻辑所使用的frameMargins一直是0
参考了直接使用clientUI的pinyin输入法，使用framePosition对光标位置做了处理